### PR TITLE
Insert Node - output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules
 public
 locales/zz-ZZ
 nodes/core/locales/zz-ZZ
+.idea

--- a/src/ckants_io.html
+++ b/src/ckants_io.html
@@ -43,6 +43,37 @@
   </div>
 </script>
 
+<script type="text/x-red" data-help-name="ckants insert output">
+  <p>This node sends data to CKAN Datastore via datastore_upsert API. </p>
+  <p>It receives a msg whose payload is an <b>array</b> of records to be pushed to the CKAN Datastore resource.</p>
+
+  <p>It also supports sending data to CKAN Timeseries API, a new extension that allows CKAN to work with timeseries data. More at <a href="https://github.com/namgk/ckan-timeseries">CKAN Timeseries Github</a></p>
+
+  <p>The records should conform the resource schema as specified when the resource was being created: <b>correct data type</b>, <b>have exact number of fields</b>.</p>
+  <p><b>Note: Timeseries API will not be able to work with resources created by original Datastore API</b></p>
+
+  <p>The node returns whether the insert into CKAN was successful, in addition to the existing msg object. This allows you to return a success or failure HTTP response to the request initializer depending on the value in <b>msg.payload.success</b>.</p>
+</script>
+
+<script type="text/x-red" data-template-name="ckants insert output">
+  <div class="form-row">
+    <label for="node-input-auth"><i class="fa"></i> CKAN Auth</label>
+    <input type="text" id="node-input-auth">
+  </div>
+  <div class="form-row">
+    <label for="node-input-resourceId"><i class="icon-tag"></i>Resource Id</label>
+    <input type="text" id="node-input-resourceId" placeholder="CKAN resource Id">
+  </div>
+  <div class="form-row">
+    <label for="node-input-name"><i class="fa fa-tag"></i> Name </label>
+    <input type="text" id="node-input-name" placeholder="A name for this node">
+  </div>
+  <div class="form-row">
+    <label>Timeseries?</label>
+    <input type="checkbox" id="node-input-timeseries" style="display: inline-block; width: auto; vertical-align: top;">
+  </div>
+</script>
+
 
 <script type="text/x-red" data-help-name="ckants search">
   <p>This node gets data from CKAN Timeseries Datastore. Default limit for returning results is 500 records per request. There is paging support in the response</p>
@@ -134,7 +165,7 @@
     }
   });
 
-  RED.nodes.registerType('ckants insert (output)',{
+  RED.nodes.registerType('ckants insert output',{
     category: 'ckants',
     defaults: {
       resourceId: {required:true},
@@ -148,7 +179,7 @@
     icon: "ckan_logo.png",
     align: "right",
     label: function() {
-        return this.name || "ckants insert (output)";
+        return this.name || "ckants insert output";
     },
     labelStyle: function() {
         return this.name ? "node_label_italic" : "";

--- a/src/ckants_io.html
+++ b/src/ckants_io.html
@@ -134,6 +134,27 @@
     }
   });
 
+  RED.nodes.registerType('ckants insert (output)',{
+    category: 'ckants',
+    defaults: {
+      resourceId: {required:true},
+      name: {required:false},
+      timeseries: {value:false, required:false},
+      auth: {type:"ckants-credentials",required:true}
+    },
+    color:color,
+    inputs:1,
+    outputs:1,
+    icon: "ckan_logo.png",
+    align: "right",
+    label: function() {
+        return this.name || "ckants insert (output)";
+    },
+    labelStyle: function() {
+        return this.name ? "node_label_italic" : "";
+    }
+  });
+
   RED.nodes.registerType('ckants sql search', {
     category: 'ckants',
     defaults: {

--- a/src/ckants_io.js
+++ b/src/ckants_io.js
@@ -270,36 +270,33 @@ module.exports = function(RED) {
         method: "insert",
         records: msg.payload
       };
+      msg.payload = {};
 
       var endpoint = node.ckan + (node.timeseries ? TIMESERIES_UPSERT : DATASTORE_UPSERT);
 
-      httpclient.post(endpoint, node.token, payload, function(res){
+      httpclient.post(endpoint, node.token, payload, function(res) {
         try {
           // Parse the response.
-          let res = JSON.parse(res);
-          assert(res.success);
-
-          // Update the existing msg object with the response.
-          for (let key of Object.keys(res)) {
-            msg.payload[key] = res[key]
-          }
+          let response = JSON.parse(res);
+          assert(response.success);
 
           // Forward the response.
           node.status({fill:"green",shape:"dot",text:"success"});
+          msg.payload.success = true;
           node.send(msg);
         }
         catch (err) {
           // Handle the error case.
           node.status({fill:"red",shape:"dot",text:"error"});
           msg.payload.success = false;
-          node.error(res);
+          node.error(err);
           node.send(msg);
         }
         setTimeout(function(){node.status({})},2000)
       });
     });
   }
-  RED.nodes.registerType("ckants insert (output)",CkantsInsertOutputNode);
+  RED.nodes.registerType("ckants insert output",CkantsInsertOutputNode);
 
   RED.httpAdmin.post("/ckants_search/:id", RED.auth.needsPermission("ckants.search"), function(req,res) {
     var node = RED.nodes.getNode(req.params.id);


### PR DESCRIPTION
I've added a new node that extends the functionality of the insert node.

This new node provides output for whether the insert into CKAN was successful, allowing developers to make decisions based on the result.

By forwarding the existing **msg** object (with **msg.payload.success** set), developers can add nodes to the right-hand side of the insert node and, for example, return an HTTP response to the caller depending on the result of the CKAN insert.

I believe this node can replace the existing insert node as it only adds functionality and nothing is removed, however, I'll leave this decision to you.

If anything needs clarification, send me a message on here or email [charlie.gillions@bristolisopen.com](mailto:charlie.gillions@bristolisopen.com).
Thanks